### PR TITLE
Initial attempt at adding external datasource

### DIFF
--- a/files/get_servicenow_node_data.rb
+++ b/files/get_servicenow_node_data.rb
@@ -1,0 +1,55 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'openssl'
+require 'net/http'
+require 'yaml'
+require 'json'
+
+# Abstract away the API calls.
+class ServiceNowRequest
+  def initialize(uri, http_verb, body, user, password)
+    @uri = URI.parse(uri)
+    @http_verb = http_verb.capitalize
+    @body = body.to_json unless body.nil?
+    @user = user
+    @password = password
+  end
+
+  def print_response
+    Net::HTTP.start(@uri.host,
+                    @uri.port,
+                    use_ssl: @uri.scheme == 'https',
+                    verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+      header = { 'Content-Type' => 'application/json' }
+      # Interpolate the HTTP verb and constantize to a class name.
+      request_class_string = "Net::HTTP::#{@http_verb}"
+      request_class = Object.const_get(request_class_string)
+      # Add uri, fields and authentication to request
+      request = request_class.new("#{@uri.path}?#{@uri.query}", header)
+      request.body = @body
+      request.basic_auth(@user, @password)
+      # Make request to ServiceNow
+      response = http.request(request)
+      # Parse and print response
+      response.body
+    end
+  rescue => e
+    raise e
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  config = YAML.load_file('/etc/puppetlabs/puppet/snow_record.yaml')
+
+  snowinstance = config['snowinstance']
+  username     = config['user']
+  password     = config['password']
+  table        = config['table']
+  fqdn         = ARGV[0]
+
+  uri = "https://#{snowinstance}.service-now.com/api/now/table/#{table}?fqdn=#{fqdn}"
+
+  request = ServiceNowRequest.new(uri, 'Get', nil, username, password)
+  response = JSON.parse(request.print_response)['result'].reduce({}, :merge)
+  puts response.to_json
+end

--- a/manifests/install_etd_script.pp
+++ b/manifests/install_etd_script.pp
@@ -1,0 +1,69 @@
+# @summary Configure ServiceNow integration on the Puppet Master
+#
+# Configure a Puppet Master to use the get-snow-node-data.rb script
+# to query information from ServiceNow to use during catalog compilation.
+# This class places required files in their directories and modifies
+# Puppet.conf to ensure the trusted_external_command setting is pointed at
+# the correct file. This class will need to be assigned to the master and
+# the correct parameter values assigned.
+#
+# @example
+#   include servicenow_integration::puppetserver
+# @param [String] snowinstance The FQDN of the ServiceNow instance to query
+# @param [String] user The username of the account with permission to query data
+# @param [String] password The password of the account used to query data from Servicenow
+# @param [String] table The table in Servicenow that will contain the required data
+# @param [String] sys_id :shrug:
+class servicenow_integration::install_etd_script (
+  String $snowinstance,
+  String $user,
+  Sensitive[String] $password,
+  String $table
+) {
+  $gem_build_dependencies = (
+    package { ['make', 'automake', 'gcc', 'gcc-c++', 'kernel-devel']:
+      ensure => present,
+    }
+  )
+
+  $resource_dependencies = flatten([
+    ['puppet_gem', 'puppetserver_gem'].map |$provider| {
+      package { "${provider} cassandra-driver":
+        ensure   => present,
+        name     => 'cassandra-driver',
+        provider => $provider,
+        require  => $gem_build_dependencies,
+      }
+    },
+
+    file { '/etc/puppetlabs/puppet/get_servicenow_node_data.rb':
+      ensure => file,
+      owner  => 'pe-puppet',
+      group  => 'pe-puppet',
+      mode   => '0755',
+      source => 'puppet:///modules/servicenow_integration/get_servicenow_node_data.rb',
+    },
+
+    file { '/etc/puppetlabs/puppet/snow_record.yaml':
+      ensure  => file,
+      owner   => 'pe-puppet',
+      group   => 'pe-puppet',
+      mode    => '0640',
+      content => epp('servicenow_integration/snow_record.yaml.epp', {
+        snowinstance => $snowinstance,
+        user         => $user,
+        password     => $password,
+        table        => $table
+      }),
+    },
+  ])
+
+  pe_ini_setting { 'puppetserver puppetconf trusted external script':
+    ensure  => present,
+    path    => '/etc/puppetlabs/puppet/puppet.conf',
+    setting => 'trusted_external_command',
+    value   => '/etc/puppetlabs/puppet/get_servicenow_node_data.rb',
+    section => 'master',
+    require => $resource_dependencies,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -2,11 +2,20 @@
   "name": "puppetlabs-servicenow_integration",
   "version": "0.1.0",
   "author": "Puppet, Inc.",
-  "summary": "",
+  "summary": "A module that allows Puppet to query ServiceNow's CMDB for node data, including classification.",
   "license": "Apache-2.0",
-  "source": "",
+  "source": "http://github.com/puppetlabs/puppetlabs-servicenow_integration",
+  "project_page": "http://github.com/puppetlabs/puppetlabs-servicenow_integration",
+  "issues_url": "http://github.com/puppetlabs/puppetlabs-servicenow_integration/issues",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/ruby_task_helper",
+      "version_requirement": ">= 0.3.0 <= 2.0.0"
+    },
+    {
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">= 1.0"
+    }
   ],
   "operatingsystem_support": [
     {

--- a/templates/snow_record.yaml.epp
+++ b/templates/snow_record.yaml.epp
@@ -1,0 +1,10 @@
+<%- | String $snowinstance,
+      String $user,
+      String $password,
+      String $table
+| -%>
+---
+snowinstance: <%= $snowinstance %>
+user: <%= $user %>
+password: <%= $password %>
+table: <%= $table %>


### PR DESCRIPTION
This change adds the files need to enable this module to act as an
external data source for SNOW data.

It adds a manifest class that will configure puppet to look for a script
that will get the data, and it adds some configuration to allow the
script to run.

At this point we probably still need a better way to set the
configuration and we will need to set about writing the script itself.

All of the previously present SNOW bolt tasks are still in place and
will still provide useful tasks for people doing the integration.