### PR TITLE
JSON-parse the class params for key-value field use

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Here's what you have to do.
 | Field Name | Column Label | Column Name | Type |
 | --- | --- | --- | --- |
 | Puppet Environment | Puppet Environment | u\_puppet\_environment | String (Full UTF-8) |
-| Puppet Classes | Puppet Classes | u\_puppet\_classes | Name-Value Pairs |
+| Puppet Classes | Puppet Classes | u\_puppet\_classes | String (Full UTF-8) |
 
 
 </center>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Here's what you have to do.
 | Field Name | Column Label | Column Name | Type |
 | --- | --- | --- | --- |
 | Puppet Environment | Puppet Environment | u\_puppet\_environment | String (Full UTF-8) |
-| Puppet Classes | Puppet Classes | u\_puppet\_classes | String (Full UTF-8) |
+| Puppet Classes | Puppet Classes | u\_puppet\_classes | Name-Value Pairs |
 
 
 </center>

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -34,6 +34,7 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       raise unless classes.is_a? Hash
 
       classes.each do |_puppet_class, params|
+        params = "{}" if params.strip.empty?
         raise unless JSON.parse(params).is_a? Hash
         classes[_puppet_class] = JSON.parse(params)
       end

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -34,7 +34,7 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       raise unless classes.is_a? Hash
 
       classes.each do |puppet_class, params|
-        case params.class
+        case params
         when Hash
           # puppet_classes was a String field type so we've
           # already parsed the params hash

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -34,11 +34,24 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       raise unless classes.is_a? Hash
 
       classes.each do |puppet_class, params|
-        next if params.is_a? Hash
-
-        params = '{}' if params.empty?
-        raise unless JSON.parse(params).is_a? Hash
-        classes[puppet_class] = JSON.parse(params)
+        case params.class
+        when Hash
+          # puppet_classes was a String field type so we've
+          # already parsed the params hash
+          next
+        when String
+          # puppet_classes was a Name-Value pairs field type
+          # so we'll need to parse the params hash and
+          # handle the possibility of an empty value for params
+          params = '{}' if params.empty?
+          raise unless JSON.parse(params).is_a? Hash
+          # If we make it here, the params field was parsed and
+          # we save the hash back into the classes var
+          classes[puppet_class] = JSON.parse(params)
+        else
+          # puppet_classes is an invalid field type
+          raise
+        end
       end
     rescue
       raise "#{classes_field} must be a json serialization of type Hash[String, Hash[String, Any]]"

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -34,7 +34,7 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       raise unless classes.is_a? Hash
 
       classes.each do |puppet_class, params|
-        params = "{}" if params.strip.empty?
+        params = '{}' if params.strip.empty?
         raise unless JSON.parse(params).is_a? Hash
         classes[puppet_class] = JSON.parse(params)
       end

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -34,7 +34,9 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       raise unless classes.is_a? Hash
 
       classes.each do |puppet_class, params|
-        params = '{}' if params.strip.empty?
+        next if params.is_a? Hash
+
+        params = '{}' if params.empty?
         raise unless JSON.parse(params).is_a? Hash
         classes[puppet_class] = JSON.parse(params)
       end

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -34,7 +34,8 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       raise unless classes.is_a? Hash
 
       classes.each do |_puppet_class, params|
-        raise unless params.is_a? Hash
+        raise unless JSON.parse(params).is_a? Hash
+        classes[_puppet_class] = JSON.parse(params)
       end
     rescue
       raise "#{classes_field} must be a json serialization of type Hash[String, Hash[String, Any]]"

--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -33,10 +33,10 @@ def parse_classification_fields(cmdb_record, classes_field, environment_field)
       classes = JSON.parse(classes)
       raise unless classes.is_a? Hash
 
-      classes.each do |_puppet_class, params|
+      classes.each do |puppet_class, params|
         params = "{}" if params.strip.empty?
         raise unless JSON.parse(params).is_a? Hash
-        classes[_puppet_class] = JSON.parse(params)
+        classes[puppet_class] = JSON.parse(params)
       end
     rescue
       raise "#{classes_field} must be a json serialization of type Hash[String, Hash[String, Any]]"


### PR DESCRIPTION
This performs a JSON.parse() on the `params` of `classes` for validation, and then overwrites the class parameter value with the JSON parsed hash.

This allows us to switch away from the `String (Full UTF-8)` field for `u_puppet_classes` and use the `Name-Value Pairs` field type instead, which provides an easier UI for the user.