### PR TITLE
Add a Jenkinsfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/rspec_junit_results.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Acceptance Testing Your Pull Request
+
+## Initial Run
+
+1. Go to the [Jenkins Pipeline for this module][1].
+2. Wait about two minutes (the repo poll interval should be 2 minutes or less) for Jenkins to check for new PR's and branches, or check for change to existing pipelines. Any new PR's will be added to the [Pull Requests View][2] or a new branch with a Jenkinsfile in it will be added to the default 'Branches' view.
+3. New PR's or branches will start to build immediately, and any changes to existed branches or PR's will be built when the repository is polled.
+
+## Viewing Run Output
+
+A build history will be on the lower left of the page with a progress indicator on the current build number. Click into the build number and then click on 'Console Output'.
+
+## Kicking Off Another Run
+
+When you push new commits to a branch or PR, you can wait for the polling interval to detect the changes, or you can go directly to your pipeline and click `Build Now`.
+
+If the only thing you want to do is make a slight change to the Jenkinsfile itself to see if something will work, or to add some `echo` debugging, you can click on `Reply` instead of `Rebuild` and a dialog will load allowing you to rebuild the same commit, but edit the Jenkinsfile manually prior to building. Your edits will affect only the current run you are about to kick off.
+
+## Viewing Results
+
+When a build of a PR or a branch is complete you can click on the build number and a 'Test Result' link will be available for you to browse through the test case hierarchy and view failed test details. You can also view the raw console output of any given build to look for more details of failed tests that way.
+
+## Testing Community Pull Requests
+
+This pipeline will not discover Pull Requests that come from community members that are not authorized collaberators on this repository. In order to test their PR's you have a couple options.
+
+1. You can add their PR commits to a branch on your own fork, and put up a PR from your own fork.
+2. You can add a branch to the upstream copy of this repository that has the community members' commits on it. The new branch will build as a branch pipeline instead of a PR pipeline.
+
+Either way please make sure to thoroughly review the commits you are adding to ensure that only authorized code can run. These pipelines are still running on internal infrastructure and we are entrusted with ensuring that no malicious code is being run.
+
+[1]: https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/view/PIE%20Team/job/pipeline_PIE_servicenow_cmdb_integration/
+[2]: https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/view/PIE%20Team/job/pipeline_PIE_servicenow_cmdb_integration/view/change-requests/

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rspec-puppet", *location_for('https://github.com/ekinanp/rspec-puppet.git#master')
   gem "hashdiff",                                                require: false
+  gem "rspec_junit_formatter",                                   require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,45 @@
+@Library('puppet_jenkins_shared_libraries@add-ruby-helper-vars') _
+
+pipeline{
+    agent {
+        label 'worker'
+    }
+    environment {
+      RUBY_VERSION='2.5.1'
+      GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
+      RAKE_SETUP_TASK='rake acceptance:setup'
+      RAKE_TEST_TASK='rake acceptance:run_tests'
+      RAKE_TEARDOWN_TASK='rake acceptance:tear_down'
+      CI='true'
+      RESULTS_FILE_NAME='rspec_junit_results.xml'
+    }
+    stages{
+
+        stage('Setup') {
+            steps {
+                echo 'Bundle Install'
+                bundleInstall env.RUBY_VERSION
+                bundleExec env.RUBY_VERSION, env.RAKE_SETUP_TASK
+            }
+        }
+
+        stage('Run Tests') {
+            steps {
+                echo 'Run Tests'
+                bundleExec env.RUBY_VERSION, env.RAKE_TEST_TASK
+            }
+        }
+    }
+    post{
+        always {
+            script {
+                if(fileExists(env.RESULTS_FILE_NAME)) {
+                    junit env.RESULTS_FILE_NAME
+                }
+            }
+        }
+        cleanup {
+            bundleExec env.RUBY_VERSION, env.RAKE_TEARDOWN_TASK
+        }
+    }
+}

--- a/Rakefile
+++ b/Rakefile
@@ -189,8 +189,10 @@ namespace :acceptance do
 
   desc 'Runs the tests'
   task :run_tests do
+    rspec_command  = 'bundle exec rspec ./spec/acceptance --format documentation'
+    rspec_command += ' --format RspecJunitFormatter --out rspec_junit_results.xml' if ENV['CI'] == 'true'
     puts("Running the tests ...\n")
-    unless system('bundle exec rspec ./spec/acceptance')
+    unless system(rspec_command)
       # system returned false which means rspec failed. So exit 1 here
       exit 1
     end

--- a/spec/support/acceptance/servicenow/mock_instance.rb
+++ b/spec/support/acceptance/servicenow/mock_instance.rb
@@ -26,16 +26,16 @@ class MockServiceNowInstance < Sinatra::Base
 
     auth_header = env['HTTP_AUTHORIZATION'] || ''
     if auth_header.start_with?('Basic')
-      username_pass = Base64.decode64(auth_header.gsub('Basic ',''))
-      unless username_pass == "mock_user:mock_password"
+      username_pass = Base64.decode64(auth_header.gsub('Basic ', ''))
+      unless username_pass == 'mock_user:mock_password'
         halt 401, to_error_response("Authorization Failed. Username/Pass incorrect.\nExpected: mock_user:mock_password\nGot: #{username_pass}")
       end
     elsif auth_header.start_with?('Bearer')
       unless auth_header == 'Bearer mock_token'
-        halt 401, to_error_response("Authorization Failed. OAuth Token incorrect\nExpected: mock_token\nGot: #{auth_header.gsub('Bearer ','')}")
+        halt 401, to_error_response("Authorization Failed. OAuth Token incorrect\nExpected: mock_token\nGot: #{auth_header.gsub('Bearer ', '')}")
       end
     else
-      halt 401, to_error_response("No authorization received. Please username: mock_user password: mock_password, or OAuthToken: mock_token.")
+      halt 401, to_error_response('No authorization received. Please use username: mock_user password: mock_password, or OAuthToken: mock_token.')
     end
   end
 

--- a/spec/support/acceptance/servicenow/mock_instance.rb
+++ b/spec/support/acceptance/servicenow/mock_instance.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'securerandom'
 require 'sinatra'
+require 'base64'
 
 # Our mock ServiceNow instance is a Sinatra server that mimics
 # the relevant ServiceNow API endpoints used by the tests
@@ -20,13 +21,22 @@ class MockServiceNowInstance < Sinatra::Base
       SSLEnable: true,
       SSLCertName: [['CN', 'Sinatra']]
 
-  # Handles authorization
-  use Rack::Auth::Basic do |user, password|
-    user == 'mock_user' && password == 'mock_password'
-  end
-
   before do
     content_type 'application/json'
+
+    auth_header = env['HTTP_AUTHORIZATION'] || ''
+    if auth_header.start_with?('Basic')
+      username_pass = Base64.decode64(auth_header.gsub('Basic ',''))
+      unless username_pass == "mock_user:mock_password"
+        halt 401, to_error_response("Authorization Failed. Username/Pass incorrect.\nExpected: mock_user:mock_password\nGot: #{username_pass}")
+      end
+    elsif auth_header.start_with?('Bearer')
+      unless auth_header == 'Bearer mock_token'
+        halt 401, to_error_response("Authorization Failed. OAuth Token incorrect\nExpected: mock_token\nGot: #{auth_header.gsub('Bearer ','')}")
+      end
+    else
+      halt 401, to_error_response("No authorization received. Please username: mock_user password: mock_password, or OAuthToken: mock_token.")
+    end
   end
 
   post '/api/now/table/:table_name' do |table_name|


### PR DESCRIPTION
DIO now supports using Jenkinsfile instead of JJB for test pipeline
creation and management. This allows a more minimal test set up and
easier management of the overall pipeline for the repo from within the
repo itself.