### PR TITLE
Dry-test the servicenow.rb script in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,12 @@ class servicenow_cmdb_integration (
     },
   ])
 
+  exec { 'dry test servicenow.rb script':
+    command     => "${external_commands_base}/servicenow.rb __dry_test__",
+    subscribe   => $resource_dependencies,
+    refreshonly => true,
+  }
+
   ini_setting { 'puppetserver puppetconf trusted external command':
     ensure  => present,
     path    => '/etc/puppetlabs/puppet/puppet.conf',
@@ -98,6 +104,6 @@ class servicenow_cmdb_integration (
     value   => "${external_commands_base}/servicenow.rb",
     section => 'master',
     notify  => Service['pe-puppetserver'],
-    require => $resource_dependencies,
+    require => Exec['dry test servicenow.rb script'],
   }
 }

--- a/spec/acceptance/node_classification_spec.rb
+++ b/spec/acceptance/node_classification_spec.rb
@@ -47,13 +47,13 @@ describe 'node classification' do
         override_environment: true,
       ),
     )
-    master.apply_manifest(setup_manifest)
+    master.apply_manifest(setup_manifest, catch_failures: true)
     master.run_shell("puppet task run servicenow_cmdb_integration::add_environment_rule --params '{\"group_names\": [\"#{TEST_ENVIRONMENT}\"]}' --nodes #{master.uri}")
   end
   after(:all) do
     # Teardown the test environment
     master.run_shell("rm -rf #{TEST_ENVIRONMENT_CODE_DIR}")
-    master.apply_manifest(declare('node_group', TEST_ENVIRONMENT, ensure: 'absent'))
+    master.apply_manifest(declare('node_group', TEST_ENVIRONMENT, ensure: 'absent'), catch_failures: true)
   end
 
   # Setup the trusted external data feature since classification depends on it.
@@ -64,7 +64,7 @@ describe 'node classification' do
       declare('Service', 'pe-puppetserver'),
       declare('class', 'servicenow_cmdb_integration', params),
     )
-    master.apply_manifest(setup_manifest)
+    master.apply_manifest(setup_manifest, catch_failures: true)
   end
 
   shared_examples 'classification tests' do |classes_field: 'u_puppet_classes', environment_field: 'u_puppet_environment'|

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -38,6 +38,11 @@ rescue => e
   raise "Failed to parse the #{desc} JSON: #{e}\nPuppet output:\n#{puppet_output}"
 end
 
+def clear_trusted_external_data_setup
+  master.run_shell('rm -rf /etc/puppetlabs/puppet/trusted-external-commands/')
+  master.run_shell('puppet config delete trusted_external_command --section master')
+end
+
 def declare(type, title, params = {})
   params = params.map do |name, value|
     value = "'#{value}'" if value.is_a?(String)


### PR DESCRIPTION
The dry-testing work also captured some bugs in the servicenow.rb
script, namely that it doesn't properly handle error responses from
ServiceNow's API.

This commit also fixes uses of apply_manifest to properly catch failures
in the acceptance tests.

Resolves #44

Signed-off-by: Enis Inan <enis.inan@puppet.com>