### PR TITLE
(PIE-321) Backfill Gettings Started Guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,22 @@ If you'd like to also classify nodes in ServiceNow's CMDB, then the module:
 
 ### Beginning with servicenow_cmdb_integration
 
-**Note:** If you're interested in both the ServiceNow CMDB external data and node classification features of this module, then you can just read the [classification](#ServiceNow-node-classification) section since that depends on the CMDB external data feature.
+Pre-reqs:
+  * Puppet Enterprise version 2019.7.0 or newer
+  * A ServiceNow instance (dev or enterprise)
+
+
+**Note** The trusted external data feature does not depend on the classification feature, so you can enable it on its own. However, if you’re also interested in classifying nodes in the CMDB, you must enable both features. If you're interested in both the ServiceNow CMDB external data and node classification features of this module, then you can just read the [classification](#ServiceNow-node-classification) section since that depends on the CMDB external data feature.
 
 #### ServiceNow CMDB as trusted external data
-Apply the `servicenow_cmdb_integration` class on all of your compilers. This looks something like:
+
+1. Install the `puppetlabs-servicenow_cmdb_integration` module on your Puppet master.
+
+2.  Add the `servicenow_cmdb_integration` class to the `PE Master` node group.
+In the PE console, navigate to `Classification` then expand the `PE Infrastructure` group
+Click `PE Master` then `Configuration`
+Add the `servicenow_cmdb_integration` class
+Enable these parameters:
 
 ```
 class { 'servicenow_cmdb_integration':
@@ -60,17 +72,19 @@ class { 'servicenow_cmdb_integration':
 }
 ```
 
-Please note that you may specify a user/password or an oauth token, but not both.
+> If you’re using a hiera-eyaml encrypted password, then make sure that `eyaml decrypt -s <encrypted_password>` returns the same password on all nodes in the `PE Master` node group.
 
-> If you're using a hiera-eyaml encrypted password, then make sure that `eyaml decrypt -s <encrypted_password>` returns the same password on all nodes in the `PE Master` node group.
+> You can also pass-in a plain-text or hiera-eyaml encrypted oauth token via the `oauth_token` parameter instead of a username/password. Please note that you may specify a user/password or an oauth token, but not both. Similar to a hiera-eyaml encrypted password, If you’re passing-in a hiera-eyaml encrypted oauth token, then make sure that `eyaml decrypt -s <encrypted_oauth_token>` returns the same oauth token on all nodes in the `PE Master` node group.
 
-> For customers using PE 2019.7+, we recommend adding this class to the `PE Master` node group. If HA is installed, then it should also be added to the `PE HA Replica` group.
+Commit the changes, then run Puppet on the node group. This will cause a restart of the `pe-puppetserver` service.
 
-This class installs the `servicenow.rb` script. The script fetches the node's CMDB record from the `cmdb_ci` table and stores it in the `trusted.external.servicenow` variable. This variable is a hash of `<field> => <value>` where `<field>` is a field in the `cmdb_ci` table and `<value>` is the field's value. If the field's a reference field then `<value>` is that field's display value.
+The `servicenow_cmdb_integration` class installs the `servicenow.rb` script and points Puppet’s `trusted_external_command` setting to that script. This script fetches the node's CMDB record from the `cmdb_ci` table and stores it in the `trusted.external.servicenow` variable.
+
+You can set the `table` parameter to point to a different CMDB table (like e.g. `cmdb_ci_server`). However, keep in mind that the script will only fetch data for nodes that are in the specified table _or_ a child of that table (such as nodes in the `cmdb_ci_server` table or a child table like `cmdb_ci_server_hardware`). It will return an empty hash for all other nodes.
 
 **Note:** Puppet invokes the `servicenow.rb` script via the calling-convention `servicenow.rb <certname>`. The script fetches the node's CMDB record by querying the record whose `fqdn` field matches `<certname>`. If you're storing node certnames in a separate CMDB field, then you can set the `certname_field` parameter to that CMDB field's _column name_.
 
-**Note to readers from the classification section:** If you're already storing the node's environment and classes in your own CMDB fields, then make sure to specify those fields' column names in the `environment_field` and `classes_field` parameters, respectively. Otherwise, these default to `u_puppet_environment` and `u_puppet_classes`, respectively.
+**Note to readers who are enabling classification:** If you're already storing the node's environment and classes in their own CMDB fields, then make sure to specify those fields' _column names_ in the `environment_field` and `classes_field` parameters, respectively. Otherwise, these default to `u_puppet_environment` and `u_puppet_classes`, respectively.
 
 #### ServiceNow node classification
 
@@ -93,12 +107,30 @@ Here's what you have to do.
 
 Here, `Puppet Classes` is a JSON encoding of a `Hash[String, Hash[String, Any]]` type (informally, a `Hash[ClassName, Parameters]` object). For example, `"{\"foo_class\":{\"foo_param\":\"foo_value\"}}"` is a valid value for `Puppet Classes`. However, `{"foo_class":{"foo_param":"foo_value"}}` is not.
 
+**Note:** You can also make `Puppet Classes` a `Name-Value pairs` field type, where the `Name` corresponds to the classes and `Value` corresponds to the parameters. If you choose to do this, then know that ServiceNow’s API will return `Puppet Classes` as a JSON encoding of a `Hash[String, String]` type. For example, given a `classes` hash that’s something like `{"foo_class":{"foo_param":"foo_value"}}` that’s stored as a `String (Full UTF-8)` field type, ServiceNow’s API will return this as:
+```
+”{\”foo_class\”:\”{\”foo_param\”:\”foo_value\”}\”}”
+```
+(if stored as a `Name-Value pairs` field type) vs.
+```
+”{\”foo_class\”:{\”foo_param\”:\”foo_value\”}}”
+```
+This means that parsing the classes hash for a `Name-Value pairs` field type will look something like:
+```
+classes = JSON.parse(raw_value)
+classes.each do |class, params|
+  classes[class] = JSON.parse(params)
+end
+```
+Or something like `classes = JSON.parse(raw_value)` for the `String (Full UTF-8)` field type.
+
+
 2\. In your control-repo, create a commit that:
 
 * Adds the following to the `Puppetfile`:
 
 	```
-   mod 'puppetlabs/servicenow_cmdb_integration'
+   mod ‘puppetlabs/servicenow_cmdb_integration’, :latest
 	```
 
 * Adds the following Hiera backend to the `hiera.yaml` file:
@@ -137,6 +169,66 @@ puppet task run servicenow_cmdb_integration::add_environment_rule --params '{"gr
 > This step's necessary for the integration to set the node's environment to `Puppet Environment`.
 
 4\. Setup the trusted external command by following the instructions in the [trusted external data](#ServiceNow-CMDB-as-trusted-external-data) section.
+
+#### ServiceNow CMDB as trusted external data
+
+1. Install the `puppetlabs-servicenow_cmdb_integration` module on your Puppet master.
+
+2. Add the `servicenow_cmdb_integration` class to the `PE Master` node group.
+In the PE console, navigate to `Classification` then expand the `PE Infrastructure` group
+Click `PE Master` then `Configuration`
+Add the `servicenow_cmdb_integration` class
+Enable these parameters:
+
+```
+class { 'servicenow_cmdb_integration':
+  instance    => '<fqdn_of_snow_instance>',
+  user        => '<user>',
+  password    => '<password>',
+}
+```
+
+Or if you'd prefer to use an OAuth token:
+
+```
+class { 'servicenow_cmdb_integration':
+  instance    => '<fqdn_of_snow_instance>',
+  oauth_token => '<snow_oauth_token>',
+}
+```
+
+> If you’re using a hiera-eyaml encrypted password, then make sure that `eyaml decrypt -s <encrypted_password>` returns the same password on all nodes in the `PE Master` node group.
+
+> You can also pass-in a plain-text or hiera-eyaml encrypted oauth token via the `oauth_token` parameter instead of a username/password. Please note that you may specify a user/password or an oauth token, but not both. Similar to a hiera-eyaml encrypted password, If you’re passing-in a hiera-eyaml encrypted oauth token, then make sure that `eyaml decrypt -s <encrypted_oauth_token>` returns the same oauth token on all nodes in the `PE Master` node group.
+
+Commit the changes, then run Puppet on the node group. This will cause a restart of the `pe-puppetserver` service.
+
+The `servicenow_cmdb_integration` class installs the `servicenow.rb` script and points Puppet’s `trusted_external_command` setting to that script. This script fetches the node's CMDB record from the `cmdb_ci` table and stores it in the `trusted.external.servicenow` variable.
+
+You can set the `table` parameter to point to a different CMDB table (like e.g. `cmdb_ci_server`). However, keep in mind that the script will only fetch data for nodes that are in the specified table _or_ a child of that table (such as nodes in the `cmdb_ci_server` table or a child table like `cmdb_ci_server_hardware`). It will return an empty hash for all other nodes.
+
+**Note:** Puppet invokes the `servicenow.rb` script via the calling-convention `servicenow.rb <certname>`. The script fetches the node's CMDB record by querying the record whose `fqdn` field matches `<certname>`. If you're storing node certnames in a separate CMDB field, then you can set the `certname_field` parameter to that CMDB field's _column name_.
+
+**Note to readers who are enabling classification:** If you're already storing the node's environment and classes in their own CMDB fields, then make sure to specify those fields' _column names_ in the `environment_field` and `classes_field` parameters, respectively. Otherwise, these default to `u_puppet_environment` and `u_puppet_classes`, respectively.
+
+3. (Optional) To verify that everything worked, click on one of the nodes in the Matching nodes tab of the PE Master group and scroll down to the node’s trusted facts. You should see something like:
+
+```
+"external": {
+  "servicenow": {
+    "asset": {
+     }
+     ...
+  }
+}
+```
+> If you see an empty hash for trusted.external, then run Puppet again on the node to refresh the data.
+
+If you see an empty hash for trusted.external.servicenow, then the CMDB table that you’re fetching the data from might not have an entry for the node, or you might need to set the `servicenow_cmdb_integration` class’ `certname_field` parameter to a valid value.
+
+**Note to readers who are enabling classification:** If classification’s been properly set up, then you should also see values for the `trusted.external.servicenow` hash’s `puppet_environment` and `puppet_classes` keys, respectively.
+
+You should now be able to reference the node’s CMDB record when writing your Puppet manifests. For example, the line `getvar(‘trusted.external.servicenow.asset_tag’)` (or `$trusted[‘external’][‘servicenow’][‘asset_tag’]`) returns the node’s asset tag.
 
 
 ## Development


### PR DESCRIPTION
Backfilled missing portions of the getting started guide
(https://docs.google.com/document/d/1qcevkzvkXayNCZVrkENFTS51DKV4eA30ozU3hjZKOR4)
back to the README. We link to the getting started guide which currently
is a goolge doc, but will be replaced by the proper link once it's
published (PIE-322). Even though this README is a bit long I opted not
to break it into a docs folder because the relative links break the
forge README page unless you link to a specific release tag which takes
you back to github anyways. This is longer, but substantially simpler.