### PR TITLE
(PIE-325) Relax version requirements for some dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,7 +11,7 @@ fixtures:
       ref: "0.5.1"
     inifile:
       repo: "puppetlabs/inifile"
-      ref: "4.2.0"
+      ref: "1.0.0"
   repositories:
     "stdlib":
       "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "WhatsARanjit/node_manager",
-      "version_requirement": ">= 0.7.3 < 0.8.0"
+      "version_requirement": ">= 0.7.3 < 1.0.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 4.2.0 <= 4.3.0"
+      "version_requirement": ">= 1.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/ruby_task_helper",
-      "version_requirement": ">= 0.5.1 <= 1.0.0"
+      "version_requirement": ">= 0.5.1 < 1.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
node_manager:
  0.7.3 is the first version when Puppet 6 support was added. So, this
commit changes the max version to 1.0.0, a version that (could) contain
a breaking change.

inifile:
  1.0.0 is the first released version of the module on the Forge. We
also extend the upper bound to 5.0.0 since that is also likely to
contain a breaking change.

ruby_task_helper:
  We make the upper bound '< 1.0.0' to fix a mistake from the previous
commit (since 1.0.0 could also be a breaking version).

Signed-off-by: Enis Inan <enis.inan@puppet.com>