### PR TITLE
(PIE-385) Fix config validation dry run test

### DIFF
--- a/files/servicenow.rb
+++ b/files/servicenow.rb
@@ -114,8 +114,9 @@ class ServiceNowRequest
   end
 end
 
-def servicenow(certname)
-  servicenow_config = YAML.load_file('/etc/puppetlabs/puppet/servicenow_cmdb.yaml')
+def servicenow(certname, config_file = nil)
+  config_path = config_file.nil? ? '/etc/puppetlabs/puppet/servicenow_cmdb.yaml' : config_file
+  servicenow_config = YAML.load_file(config_path)
 
   instance          = servicenow_config['instance']
   username          = servicenow_config['user']

--- a/spec/acceptance/node_classification_spec.rb
+++ b/spec/acceptance/node_classification_spec.rb
@@ -54,6 +54,7 @@ describe 'node classification' do
     # Teardown the test environment
     master.run_shell("rm -rf #{TEST_ENVIRONMENT_CODE_DIR}")
     master.apply_manifest(declare('node_group', TEST_ENVIRONMENT, ensure: 'absent'), catch_failures: true)
+    CMDBHelpers.delete_target_record(master)
   end
 
   # Setup the trusted external data feature since classification depends on it.
@@ -82,13 +83,11 @@ describe 'node classification' do
     end
 
     before(:each) do
+      CMDBHelpers.delete_target_record(master)
       fields_template = JSON.parse(File.read('spec/support/acceptance/cmdb_record_template.json'))
       fields_template[classes_field] = classes.to_json
       fields_template[environment_field] = TEST_ENVIRONMENT
       CMDBHelpers.create_target_record(master, fields_template)
-    end
-    after(:each) do
-      CMDBHelpers.delete_target_record(master)
     end
 
     it "lets users classify nodes in ServiceNow's CMDB" do

--- a/templates/validate_settings.rb.epp
+++ b/templates/validate_settings.rb.epp
@@ -1,0 +1,9 @@
+<%- | String $require_path
+| -%>
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require_relative '<%= $require_path %>'
+
+if $PROGRAM_NAME == __FILE__
+  servicenow('__test__', ARGV[0])
+end


### PR DESCRIPTION
The module needs to be able to run a validation test on any parameters
that are stored in the configuration yaml file.

This change fixes a bug whereby it was possible to write a bad
configuration to disk and it was then impossible to fix it.

This new method of validation will be better at preventing an invalid
configuration from every being stored.