### PR TITLE
MAINT Fix Acceptance bugs

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -19,5 +19,7 @@ fixtures:
       "repo": "https://github.com/puppetlabs/puppetlabs-translate"
     facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    provision:
+      repo: "git://github.com/puppetlabs/provision.git"
+      ref: "1ddac67b8a6f829c545103185c05291a47e0776e"
     servicenow_tasks: 'git://github.com/puppetlabs/servicenow_tasks.git'

--- a/Gemfile
+++ b/Gemfile
@@ -24,14 +24,16 @@ group :development do
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet_litmus", '~> 0.18',                                require: false, platforms: [:ruby]
+  # Temporarily setting puppet_litmus version to 0.26.0 or older because new litmus version changes where the inventory file gets
+  # created/the name changes to litmus_inventory.yml which is not compatible with the current tests.
+  gem "puppet_litmus", '~> 0.18', '<= 0.26.0',                   require: false, platforms: [:ruby]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "rspec-puppet", *location_for('https://github.com/ekinanp/rspec-puppet.git#master')
-  gem "hashdiff",                                                require: false
   gem "rspec_junit_formatter",                                   require: false
+  gem "hashdiff",                                                require: false
+  gem "pdk",                                                     require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline{
         label 'worker'
     }
     environment {
-      RUBY_VERSION='2.5.1'
+      RUBY_VERSION='2.5.7'
       GEM_SOURCE='https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
       RAKE_SETUP_TASK='rake acceptance:setup'
       RAKE_TEST_TASK='rake acceptance:run_tests'

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -1,4 +1,5 @@
 require 'puppet_litmus'
+PuppetLitmus.configure!
 # rubocop:disable Style/BracesAroundHashParameters
 
 # The Target class and TargetHelpers module are a useful ways
@@ -94,7 +95,7 @@ module CMDBHelpers
     end
     task_result = servicenow_instance.run_bolt_task(
       'servicenow_tasks::create_record',
-      { 'table' => table, 'fields' => fields.merge(certname_field => target.uri) }
+      { 'table' => table, 'fields' => fields.merge(certname_field => target.uri).to_json }
     )
     task_result.result['result']
   end
@@ -103,7 +104,7 @@ module CMDBHelpers
   def get_target_record(target, table: 'cmdb_ci', certname_field: 'fqdn')
     task_result = servicenow_instance.run_bolt_task(
       'servicenow_tasks::get_records',
-      { 'table' => table, 'url_params' => { certname_field => target.uri, 'sysparm_display_value' => true } },
+      { 'table' => table, 'url_params' => { certname_field => target.uri, 'sysparm_display_value' => true }.to_json },
     )
     satisfying_records = task_result.result['result']
     return nil if satisfying_records.empty?


### PR DESCRIPTION
Changed ruby ver: Puppetfile-resolver gem requires Ruby 2.5.3 or better.

Unpin rspec-puppet location

Pinned provision and litmus versions

Add PDK Gem